### PR TITLE
Change default shortcut to Ctrl+Q/Cmd+Q

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Youtube Preview Link: [https://youtu.be/BcpD38IjY6A](https://youtu.be/BcpD38IjY6
 - Search and filter tabs.
 - Context menu on tabs.
 - Toggle the sidebar by clicking on the extension icon.
-- Toggle the sidebar using the keyboard shortcut: **`Cmd + E`** (**`Ctrl + E`** on PC) ~~or `Ctrl` + `` ` `` or `Ctrl` + `Esc` or `Cmd` + `Esc` or `Opt` + `Esc` or `Alt` + `Esc`~~
+- Toggle the sidebar using the keyboard shortcut: **`Cmd + Q`** (**`Ctrl + Q`** on PC) (You can change this via chrome://extensions/shortcuts)
   - Using keyboard shortcuts are recommended once you formed the corresponding muscle memory.
 - The sidebar is resizable, and can be put on either the left or right of the browser window.
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -28,8 +28,8 @@
   "commands": {
     "_execute_browser_action": {
       "suggested_key": {
-        "default": "Ctrl+E",
-        "mac": "Command+E"
+        "default": "Ctrl+Q",
+        "mac": "Command+Q"
       }
     }
   },

--- a/src/pages/Background/helpers/InstallationHelper.js
+++ b/src/pages/Background/helpers/InstallationHelper.js
@@ -44,7 +44,7 @@ chrome.storage.local.get(['shouldShowTips'], (result) => {
 });
 
 chrome.browserAction.setTitle({
-  title: `Vertical Tabs: Use Command + E (Ctrl + E on PC) to toggle the sidebar`,
+  title: `Vertical Tabs: Use Command + Q (Ctrl + Q on PC) to toggle the sidebar`,
 });
 
 const persistShouldShowTipsStatus = (toStatus) => {


### PR DESCRIPTION
- The default activation shortcut is changed to Ctrl+Q/Cmd+Q to avoid the collision with Chrome's default "Search from anywhere on the page" shortcut.
- The extension tooltip and README.md have been changed accordingly too.